### PR TITLE
include directive for <cstring> header file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <cstring>
 #include "surface.h"
 
 #define STR_ENDS_WITH(S, E) (strcmp(S + strlen(S) - (sizeof(E) - 1), E) == 0)


### PR DESCRIPTION
Add include directive for <cstring> header file in main.cpp

This commit adds an include directive for the <cstring> header file to the main.cpp file. This fixes the "strlen" and "strcmp" functions not being recognized by the compiler during the build process.